### PR TITLE
Add CreatePullRequest, GetReleases and GetRepository tasks

### DIFF
--- a/src/Nuke.GitHub/GitHubSettingsExtensions.cs
+++ b/src/Nuke.GitHub/GitHubSettingsExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common.Tooling;
+
+namespace Nuke.GitHub
+{
+    /// <summary><p>Used within <see cref="GitHubTasks"/>.</p></summary>
+    public static partial class GitHubSettingsExtensions
+    {
+        #region RepositoryOwner
+        /// <summary><p><em>Sets <see cref="GitHubSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
+        [Pure]
+        public static T SetRepositoryOwner<T>(this T toolSettings, string repositoryOwner) where T : GitHubSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryOwner = repositoryOwner;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
+        [Pure]
+        public static T ResetRepositoryOwner<T>(this T toolSettings) where T : GitHubSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryOwner = null;
+            return toolSettings;
+        }
+        #endregion
+        #region RepositoryName
+        /// <summary><p><em>Sets <see cref="GitHubSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
+        [Pure]
+        public static T SetRepositoryName<T>(this T toolSettings, string repositoryName) where T : GitHubSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryName = repositoryName;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
+        [Pure]
+        public static T ResetRepositoryName<T>(this T toolSettings) where T : GitHubSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryName = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Token
+        /// <summary><p><em>Sets <see cref="GitHubSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
+        [Pure]
+        public static T SetToken<T>(this T toolSettings, string token) where T : GitHubSettings
+        {
+            var x = new GitHubReleaseSettings();
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Token = token;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
+        [Pure]
+        public static T ResetToken<T>(this T toolSettings) where T : GitHubSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Token = null;
+            return toolSettings;
+        }
+        #endregion
+    }
+}

--- a/src/Nuke.GitHub/GitHubTasks.Generated.cs
+++ b/src/Nuke.GitHub/GitHubTasks.Generated.cs
@@ -26,7 +26,7 @@ namespace Nuke.GitHub
     [PublicAPI]
     [ExcludeFromCodeCoverage]
     [Serializable]
-    public partial class GitHubReleaseSettings : ToolSettings
+    public partial class GitHubReleaseSettings : GitHubSettings
     {
         /// <summary><p>Optional file paths for files that should be appended to a release</p></summary>
         public virtual string[] ArtifactPaths { get; internal set; }
@@ -34,24 +34,61 @@ namespace Nuke.GitHub
         public virtual string ReleaseNotes { get; internal set; }
         /// <summary><p>The tag that should be used for the release, e.g. "v1.0.0"</p></summary>
         public virtual string Tag { get; internal set; }
-        /// <summary><p>The Token for the GitHub API</p></summary>
-        public virtual string Token { get; internal set; }
         /// <summary><p>The commit SHA on which to create the release</p></summary>
         public virtual string CommitSha { get; internal set; }
-        /// <summary><p>The account under which the repository is hosted</p></summary>
-        public virtual string RepositoryOwner { get; internal set; }
-        /// <summary><p>The name of the repository</p></summary>
-        public virtual string RepositoryName { get; internal set; }
         /// <summary><p>Whether this is a pre-release</p></summary>
         public virtual bool? Prerelease { get; internal set; } = false;
         protected override void AssertValid()
         {
             base.AssertValid();
             ControlFlow.Assert(Tag != null, "Tag != null");
-            ControlFlow.Assert(Token != null, "Token != null");
             ControlFlow.Assert(CommitSha != null, "CommitSha != null");
+        }
+    }
+    #endregion
+    #region GitHubPullRequestSettings
+    /// <summary><p>Used within <see cref="GitHubTasks"/>.</p></summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class GitHubPullRequestSettings : GitHubSettings
+    {
+        /// <summary><p>The name of the branch you want the changes pulled into</p></summary>
+        public virtual string Base { get; internal set; }
+        /// <summary><p>The name of the branch where your changes are implemented</p></summary>
+        public virtual string Head { get; internal set; }
+        /// <summary><p>The title of the pull request</p></summary>
+        public virtual string Title { get; internal set; }
+        /// <summary><p>The optional contents of the pull request</p></summary>
+        public virtual string Body { get; internal set; }
+        protected override void AssertValid()
+        {
+            base.AssertValid();
+            ControlFlow.Assert(Base != null, "Base != null");
+            ControlFlow.Assert(Head != null, "Head != null");
+            ControlFlow.Assert(Title != null, "Title != null");
+        }
+    }
+    #endregion
+    #region GitHubSettings
+    /// <summary><p>Used within <see cref="GitHubTasks"/>.</p></summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class GitHubSettings : ToolSettings
+    {
+        /// <summary><p>The account under which the repository is hosted</p></summary>
+        public virtual string RepositoryOwner { get; internal set; }
+        /// <summary><p>The name of the repository</p></summary>
+        public virtual string RepositoryName { get; internal set; }
+        /// <summary><p>The Token for the GitHub API</p></summary>
+        public virtual string Token { get; internal set; }
+        protected override void AssertValid()
+        {
+            base.AssertValid();
             ControlFlow.Assert(RepositoryOwner != null, "RepositoryOwner != null");
             ControlFlow.Assert(RepositoryName != null, "RepositoryName != null");
+            ControlFlow.Assert(Token != null, "Token != null");
         }
     }
     #endregion
@@ -115,24 +152,6 @@ namespace Nuke.GitHub
             return toolSettings;
         }
         #endregion
-        #region Token
-        /// <summary><p><em>Sets <see cref="GitHubReleaseSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings SetToken(this GitHubReleaseSettings toolSettings, string token)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.Token = token;
-            return toolSettings;
-        }
-        /// <summary><p><em>Resets <see cref="GitHubReleaseSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings ResetToken(this GitHubReleaseSettings toolSettings)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.Token = null;
-            return toolSettings;
-        }
-        #endregion
         #region CommitSha
         /// <summary><p><em>Sets <see cref="GitHubReleaseSettings.CommitSha"/>.</em></p><p>The commit SHA on which to create the release</p></summary>
         [Pure]
@@ -148,42 +167,6 @@ namespace Nuke.GitHub
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.CommitSha = null;
-            return toolSettings;
-        }
-        #endregion
-        #region RepositoryOwner
-        /// <summary><p><em>Sets <see cref="GitHubReleaseSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings SetRepositoryOwner(this GitHubReleaseSettings toolSettings, string repositoryOwner)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.RepositoryOwner = repositoryOwner;
-            return toolSettings;
-        }
-        /// <summary><p><em>Resets <see cref="GitHubReleaseSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings ResetRepositoryOwner(this GitHubReleaseSettings toolSettings)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.RepositoryOwner = null;
-            return toolSettings;
-        }
-        #endregion
-        #region RepositoryName
-        /// <summary><p><em>Sets <see cref="GitHubReleaseSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings SetRepositoryName(this GitHubReleaseSettings toolSettings, string repositoryName)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.RepositoryName = repositoryName;
-            return toolSettings;
-        }
-        /// <summary><p><em>Resets <see cref="GitHubReleaseSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
-        [Pure]
-        public static GitHubReleaseSettings ResetRepositoryName(this GitHubReleaseSettings toolSettings)
-        {
-            toolSettings = toolSettings.NewInstance();
-            toolSettings.RepositoryName = null;
             return toolSettings;
         }
         #endregion
@@ -226,6 +209,148 @@ namespace Nuke.GitHub
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Prerelease = !toolSettings.Prerelease;
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+    #region GitHubPullRequestSettingsExtensions
+    /// <summary><p>Used within <see cref="GitHubTasks"/>.</p></summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class GitHubPullRequestSettingsExtensions
+    {
+        #region Base
+        /// <summary><p><em>Sets <see cref="GitHubPullRequestSettings.Base"/>.</em></p><p>The name of the branch you want the changes pulled into</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings SetBase(this GitHubPullRequestSettings toolSettings, string @base)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Base = @base;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubPullRequestSettings.Base"/>.</em></p><p>The name of the branch you want the changes pulled into</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings ResetBase(this GitHubPullRequestSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Base = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Head
+        /// <summary><p><em>Sets <see cref="GitHubPullRequestSettings.Head"/>.</em></p><p>The name of the branch where your changes are implemented</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings SetHead(this GitHubPullRequestSettings toolSettings, string head)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Head = head;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubPullRequestSettings.Head"/>.</em></p><p>The name of the branch where your changes are implemented</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings ResetHead(this GitHubPullRequestSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Head = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Title
+        /// <summary><p><em>Sets <see cref="GitHubPullRequestSettings.Title"/>.</em></p><p>The title of the pull request</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings SetTitle(this GitHubPullRequestSettings toolSettings, string title)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Title = title;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubPullRequestSettings.Title"/>.</em></p><p>The title of the pull request</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings ResetTitle(this GitHubPullRequestSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Title = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Body
+        /// <summary><p><em>Sets <see cref="GitHubPullRequestSettings.Body"/>.</em></p><p>The optional contents of the pull request</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings SetBody(this GitHubPullRequestSettings toolSettings, string body)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Body = body;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubPullRequestSettings.Body"/>.</em></p><p>The optional contents of the pull request</p></summary>
+        [Pure]
+        public static GitHubPullRequestSettings ResetBody(this GitHubPullRequestSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Body = null;
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+    #region GitHubSettingsExtensions
+    /// <summary><p>Used within <see cref="GitHubTasks"/>.</p></summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class GitHubSettingsExtensions
+    {
+        #region RepositoryOwner
+        /// <summary><p><em>Sets <see cref="GitHubSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
+        [Pure]
+        public static GitHubSettings SetRepositoryOwner(this GitHubSettings toolSettings, string repositoryOwner)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryOwner = repositoryOwner;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.RepositoryOwner"/>.</em></p><p>The account under which the repository is hosted</p></summary>
+        [Pure]
+        public static GitHubSettings ResetRepositoryOwner(this GitHubSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryOwner = null;
+            return toolSettings;
+        }
+        #endregion
+        #region RepositoryName
+        /// <summary><p><em>Sets <see cref="GitHubSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
+        [Pure]
+        public static GitHubSettings SetRepositoryName(this GitHubSettings toolSettings, string repositoryName)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryName = repositoryName;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.RepositoryName"/>.</em></p><p>The name of the repository</p></summary>
+        [Pure]
+        public static GitHubSettings ResetRepositoryName(this GitHubSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryName = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Token
+        /// <summary><p><em>Sets <see cref="GitHubSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
+        [Pure]
+        public static GitHubSettings SetToken(this GitHubSettings toolSettings, string token)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Token = token;
+            return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.Token"/>.</em></p><p>The Token for the GitHub API</p></summary>
+        [Pure]
+        public static GitHubSettings ResetToken(this GitHubSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Token = null;
             return toolSettings;
         }
         #endregion

--- a/src/Nuke.GitHub/MetaData/GitHubTasks.json
+++ b/src/Nuke.GitHub/MetaData/GitHubTasks.json
@@ -11,6 +11,7 @@
   "dataClasses": [
     {
       "name": "GitHubReleaseSettings",
+      "baseClass": "GitHubSettings",
       "extensionMethods": true,
       "properties": [
         {
@@ -30,17 +31,53 @@
           "help": "The tag that should be used for the release, e.g. \"v1.0.0\""
         },
         {
-          "name": "Token",
-          "type": "string",
-          "assertion": "NotNull",
-          "help": "The Token for the GitHub API"
-        },
-        {
           "name": "CommitSha",
           "type": "string",
           "assertion": "NotNull",
           "help": "The commit SHA on which to create the release"
         },
+        {
+          "name": "Prerelease",
+          "type": "bool",
+          "default": "false",
+          "help": "Whether this is a pre-release"
+        }
+      ]
+    },
+    {
+      "name": "GitHubPullRequestSettings",
+      "baseClass": "GitHubSettings",
+      "extensionMethods": true,
+      "properties": [
+        {
+          "name": "Base",
+          "type": "string",
+          "assertion": "NotNull",
+          "help": "The name of the branch you want the changes pulled into"
+        },
+        {
+          "name": "Head",
+          "type": "string",
+          "assertion": "NotNull",
+          "help": "The name of the branch where your changes are implemented"
+        },
+        {
+          "name": "Title",
+          "type": "string",
+          "assertion": "NotNull",
+          "help": "The title of the pull request"
+        },
+        {
+          "name": "Body",
+          "type": "string",
+          "help": "The optional contents of the pull request"
+        }
+      ]
+    },
+    {
+      "name": "GitHubSettings",
+      "extensionMethods": true,
+      "properties": [
         {
           "name": "RepositoryOwner",
           "type": "string",
@@ -54,10 +91,10 @@
           "help": "The name of the repository"
         },
         {
-          "name": "Prerelease",
-          "type": "bool",
-          "default": "false",
-          "help": "Whether this is a pre-release"
+          "name": "Token",
+          "type": "string",
+          "assertion": "NotNull",
+          "help": "The Token for the GitHub API"
         }
       ]
     }


### PR DESCRIPTION
The `Configure<GitHubSettings>` implementation differs with yours but i'd like to keep it consistent with other Nuke targets and it also makes it a little bit easier to use ;) 