### PR TITLE
Add support for GitHub Enterprise (GHE) installations

### DIFF
--- a/src/Nuke.GitHub/GitHubSettingsExtensions.cs
+++ b/src/Nuke.GitHub/GitHubSettingsExtensions.cs
@@ -63,5 +63,24 @@ namespace Nuke.GitHub
             return toolSettings;
         }
         #endregion
-    }
+        #region GitHub Enterprise URL
+        /// <summary><p><em>Sets <see cref="GitHubSettings.Url"/>.</em></p><p>The GitHub Enterprise URL</p></summary>
+        [Pure]
+        public static T SetGitHubEnterpriseUrl<T>(this T toolSettings, string url) where T : GitHubSettings
+        {
+          var x = new GitHubReleaseSettings();
+          toolSettings = toolSettings.NewInstance();
+          toolSettings.Url = url;
+          return toolSettings;
+        }
+        /// <summary><p><em>Resets <see cref="GitHubSettings.Url"/>.</em></p><p>The GitHub Enterprise URL</p></summary>
+        [Pure]
+        public static T ResetGitHubEnterpriseUrl<T>(this T toolSettings) where T : GitHubSettings
+        {
+          toolSettings = toolSettings.NewInstance();
+          toolSettings.Url = null;
+          return toolSettings;
+        }
+        #endregion
+  }
 }

--- a/src/Nuke.GitHub/GitHubTasks.Generated.cs
+++ b/src/Nuke.GitHub/GitHubTasks.Generated.cs
@@ -101,7 +101,11 @@ namespace Nuke.GitHub
         ///   The Token for the GitHub API
         /// </summary>
         public virtual string Token { get; internal set; }
-    }
+        /// <summary>
+        ///   The URL for GitHub Enterprise 
+        /// </summary>
+        public virtual string Url { get; internal set; }
+  }
     #endregion
     #region GitHubReleaseSettingsExtensions
     /// <summary>

--- a/src/Nuke.GitHub/GitHubTasks.cs
+++ b/src/Nuke.GitHub/GitHubTasks.cs
@@ -119,7 +119,7 @@ namespace Nuke.GitHub
         {
             if (String.IsNullOrEmpty(url))
             {
-             return new GitHubClient(new ProductHeaderValue("dangl-bot"), new Uri(url))
+             return new GitHubClient(new ProductHeaderValue("dangl-bot"))
               {
 
                 Credentials = new Credentials(token)
@@ -142,5 +142,10 @@ namespace Nuke.GitHub
             var split = gitRepository.Identifier.Split('/');
             return (split[0], split[1]);
         }
-    }
+        public static (string gitHubOwner, string repositoryName) GetGitHubEnterpriseRepositoryInfo(GitRepository gitRepository)
+        {
+          var split = gitRepository.Identifier.Split('/');
+          return (split[0], split[1]);
+        }
+  }
 }

--- a/src/Nuke.GitHub/GitHubTasks.cs
+++ b/src/Nuke.GitHub/GitHubTasks.cs
@@ -121,7 +121,6 @@ namespace Nuke.GitHub
             {
              return new GitHubClient(new ProductHeaderValue("dangl-bot"))
               {
-
                 Credentials = new Credentials(token)
               };
             }
@@ -129,7 +128,6 @@ namespace Nuke.GitHub
             {
               return new GitHubClient(new ProductHeaderValue("dangl-bot"), new Uri(url))
               {
-
                 Credentials = new Credentials(token)
               };
             }           
@@ -137,11 +135,11 @@ namespace Nuke.GitHub
 
         public static (string gitHubOwner, string repositoryName) GetGitHubRepositoryInfo(GitRepository gitRepository)
         {
-            ControlFlow.Assert(gitRepository.IsGitHubRepository(), $"The {nameof(gitRepository)} parameter must reference a GitHub repository.");   
-
+            ControlFlow.Assert(gitRepository.IsGitHubRepository(), $"The {nameof(gitRepository)} parameter must reference a GitHub repository.");
             var split = gitRepository.Identifier.Split('/');
             return (split[0], split[1]);
         }
+        
         public static (string gitHubOwner, string repositoryName) GetGitHubEnterpriseRepositoryInfo(GitRepository gitRepository)
         {
           var split = gitRepository.Identifier.Split('/');


### PR DESCRIPTION
-  extended `GitHubSettings` with URL for GHE
-  extended `GetAuthenticatedClient` to take URL argument
- introduced new helper method `GetGitHubEnterpriseRepositoryInfo`